### PR TITLE
Add connect_timeout and read_timeout as configurable options

### DIFF
--- a/config/laravel-placekey.php
+++ b/config/laravel-placekey.php
@@ -40,4 +40,26 @@ return [
 
     'api_version' => 'v1',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Connect Timeout
+    |--------------------------------------------------------------------------
+    |
+    | This value is the connection timeout (in seconds) passed to the
+    | underlying HTTP client for making requests to the Placekey API.
+    |
+    */
+    // 'connect_timeout' => '5',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Read Timeout
+    |--------------------------------------------------------------------------
+    |
+    | This value is the read timeout (in seconds) passed to the
+    | underlying HTTP client for making requests to the Placekey API.
+    |
+    */
+    // 'read_timeout' => '5',
+
 ];

--- a/src/Services/PlacekeyService.php
+++ b/src/Services/PlacekeyService.php
@@ -97,10 +97,19 @@ class PlacekeyService
     protected function sendRequest($endpoint, $body)
     {
         try {
-            $response = self::$client->post($endpoint, [
+            $params = [
                 'json' => $body,
                 'http_errors' => false, // or true depends on how you want to handle http exceptions.
-            ]);
+            ];
+
+            if(isset($this->config['connect_timeout'])) {
+                $params['connect_timeout'] = $this->config['connect_timeout'];
+            }
+            if(isset($this->config['read_timeout'])) {
+                $params['read_timeout'] = $this->config['read_timeout'];
+            }
+
+            $response = self::$client->post($endpoint, $params);
 
             if ($response->getStatusCode() >= 400) {
                 throw new PlacekeyApiException($response->getReasonPhrase(), $response->getStatusCode());


### PR DESCRIPTION
Placekey API may have issues from time to time, so might be a good idea to allow the configuration of connect_timeout and read_timeout so that these API requests don't hang around forever.